### PR TITLE
Update matcher-init-query.js

### DIFF
--- a/travis.yml
+++ b/travis.yml
@@ -1,0 +1,11 @@
+language: node_js
+node_js:
+  - 12
+install:
+    
+    - npm install or npm i
+    
+script:
+    -npm start or npm test
+env:
+    Localhost:http://127.0.0.1:9990/

--- a/utils/matcher-init-query.js
+++ b/utils/matcher-init-query.js
@@ -1,3 +1,5 @@
 const envVars = require('../.env_vars');
 
-exports.matcherInitQuery = `live-server ${envVars.MATCHER_PATH} --no-browser --quiet --port=${envVars.PORT} &`;
+const liveServer = require("../node_modules/live-server/live-server");
+
+exports.matcherInitQuery = `${liveServer} ${envVars.MATCHER_PATH} --no-browser --quiet --port=${envVars.PORT} &`;


### PR DESCRIPTION
I replaced the (assumed) global live-server keyword by its respective node_modules path here.
Fixes #9 